### PR TITLE
Add support for serialization using System.Text.Json

### DIFF
--- a/src/MorganStanley.Fdc3.Json/MorganStanley.Fdc3.Json.csproj
+++ b/src/MorganStanley.Fdc3.Json/MorganStanley.Fdc3.Json.csproj
@@ -1,0 +1,49 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <RootNamespace>MorganStanley.Fdc3.Json</RootNamespace>
+        <AssemblyName>MorganStanley.Fdc3.Json</AssemblyName>
+        <VersionPrefix>2.0.0</VersionPrefix>
+        <VersionSuffix>alpha.8</VersionSuffix>
+        <Product>.NET FDC3 System.Text JSON</Product>
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>..\keypair.snk</AssemblyOriginatorKeyFile>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <LangVersion>8.0</LangVersion>
+        <RepositoryUrl>https://github.com/morganstanley/fdc3-dotnet</RepositoryUrl>
+        <Description>.NET Standard 2.0 FDC3 JSON helpers based on System.Text.Json for use with MorganStanley.Fdc3.</Description>
+        <Tags>FDC3</Tags>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <WarningLevel>9999</WarningLevel>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <WarningLevel>9999</WarningLevel>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\LICENSE">
+            <Pack>True</Pack>
+            <PackagePath></PackagePath>
+        </None>
+        <None Include="..\..\README.md">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="System.Text.Json" Version="8.0.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Fdc3.AppDirectory\MorganStanley.Fdc3.AppDirectory.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/MorganStanley.Fdc3.Json/Serialization/Fdc3AppConverter.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/Fdc3AppConverter.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.Fdc3.AppDirectory;
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace MorganStanley.Fdc3.Json.Serialization
+{
+    internal class Fdc3AppConverter : JsonConverter<Fdc3App>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(Fdc3App);
+        }
+
+        public override Fdc3App? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Utf8JsonReader readerClone = reader;
+
+            var jsonObject = JsonNode.Parse(ref readerClone);
+            if (jsonObject != null && Enum.TryParse(jsonObject["type"]?.ToString(), true, out AppType appType))
+            {
+                switch (appType)
+                {
+                    case AppType.Web:
+                        return JsonSerializer.Deserialize<Fdc3App<WebAppDetails>>(ref reader, options);
+                    case AppType.Citrix:
+                        return JsonSerializer.Deserialize<Fdc3App<CitrixAppDetails>>(ref reader, options);
+                    case AppType.Native:
+                        return JsonSerializer.Deserialize<Fdc3App<NativeAppDetails>>(ref reader, options);
+                    case AppType.OnlineNative:
+                        return JsonSerializer.Deserialize<Fdc3App<OnlineNativeAppDetails>>(ref reader, options);
+                    case AppType.Other:
+                        return JsonSerializer.Deserialize<Fdc3App<object>>(ref reader, options);
+                }
+            }
+
+            throw new InvalidOperationException("Unknown AppType. Possible values are: web, native, citrix, onlineNative, other");
+        }
+
+        public override void Write(Utf8JsonWriter writer, Fdc3App value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/MorganStanley.Fdc3.Json/Serialization/Fdc3CamelCaseNamingPolicy.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/Fdc3CamelCaseNamingPolicy.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System.Text.Json;
+
+namespace MorganStanley.Fdc3.Json.Serialization
+{
+    internal class Fdc3CamelCaseNamingPolicy : JsonNamingPolicy
+    {
+        public override string ConvertName(string name)
+        {
+            switch (name)
+            {
+                case "CURRENCY_ISOCODE":
+                case "ISOALPHA2":
+                case "ISOALPHA3":
+                case "COUNTRY_ISOALPHA2":
+                case "COUNTRY_ISOALPHA3":
+                case "FDS_ID":
+                case "BBG":
+                case "CUSIP":
+                case "FIGI":
+                case "ISIN":
+                case "PERMID":
+                case "RIC":
+                case "SEDOL":
+                case "LEI":
+                    return name;
+                default:
+                    return CamelCase.ConvertName(name);
+            }
+        }
+    }
+}

--- a/src/MorganStanley.Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
@@ -21,22 +21,15 @@ namespace MorganStanley.Fdc3.Json.Serialization
     {
         public static JsonSerializerOptions Create()
         {
-            var options = CreateWithoutCustomConverters();
-            options.Converters.Add(new Fdc3AppConverter());
-            options.Converters.Add(new RecipientJsonConverter());
-
-            return options;
-        }
-
-        internal static JsonSerializerOptions CreateWithoutCustomConverters()
-        {
             return new JsonSerializerOptions
             {
                 ReferenceHandler = ReferenceHandler.IgnoreCycles,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
                 Converters =
                 {
-                   new JsonStringEnumConverter(new Fdc3CamelCaseNamingPolicy())
+                   new JsonStringEnumConverter(new Fdc3CamelCaseNamingPolicy()),
+                   new Fdc3AppConverter(),
+                   new RecipientJsonConverter()
                 },
                 PropertyNamingPolicy = new Fdc3CamelCaseNamingPolicy()
             };

--- a/src/MorganStanley.Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
@@ -1,0 +1,45 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MorganStanley.Fdc3.Json.Serialization
+{
+    public static class Fdc3JsonSerializerOptions
+    {
+        public static JsonSerializerOptions Create()
+        {
+            var options = CreateWithoutCustomConverters();
+            options.Converters.Add(new Fdc3AppConverter());
+            options.Converters.Add(new RecipientJsonConverter());
+
+            return options;
+        }
+
+        internal static JsonSerializerOptions CreateWithoutCustomConverters()
+        {
+            return new JsonSerializerOptions
+            {
+                ReferenceHandler = ReferenceHandler.IgnoreCycles,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+                Converters =
+                {
+                   new JsonStringEnumConverter(new Fdc3CamelCaseNamingPolicy())
+                },
+                PropertyNamingPolicy = new Fdc3CamelCaseNamingPolicy()
+            };
+        }
+    }
+}

--- a/src/MorganStanley.Fdc3.Json/Serialization/RecipientJsonConverter.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/RecipientJsonConverter.cs
@@ -53,7 +53,7 @@ namespace MorganStanley.Fdc3.Json.Serialization
                 return null;
             }
 
-            return JsonSerializer.Deserialize(ref reader, targetType, Fdc3JsonSerializerOptions.CreateWithoutCustomConverters()) as IRecipient;
+            return JsonSerializer.Deserialize(ref reader, targetType, options) as IRecipient;
         }
 
         public override void Write(Utf8JsonWriter writer, IRecipient value, JsonSerializerOptions options)

--- a/src/MorganStanley.Fdc3.Json/Serialization/RecipientJsonConverter.cs
+++ b/src/MorganStanley.Fdc3.Json/Serialization/RecipientJsonConverter.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.Fdc3.Context;
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace MorganStanley.Fdc3.Json.Serialization
+{
+    internal class RecipientJsonConverter : JsonConverter<IRecipient>
+    {
+        public override bool CanConvert(Type typeToConvert)
+        {
+            return typeToConvert == typeof(IRecipient);
+        }
+
+        public override IRecipient? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Utf8JsonReader readerClone = reader;
+
+            Type? targetType = null;
+            var jsonObject = JsonNode.Parse(ref readerClone);
+            if (jsonObject == null)
+            {
+                throw new JsonException();
+            }
+
+            string? contextType = jsonObject["type"]?.ToString();
+            if (contextType == ContextTypes.Contact)
+            {
+                targetType = typeof(Contact);
+            }
+            else if (contextType == ContextTypes.ContactList)
+            {
+                targetType = typeof(ContactList);
+            }
+
+            if (targetType == null)
+            {
+                return null;
+            }
+
+            return JsonSerializer.Deserialize(ref reader, targetType, Fdc3JsonSerializerOptions.CreateWithoutCustomConverters()) as IRecipient;
+        }
+
+        public override void Write(Utf8JsonWriter writer, IRecipient value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.Newtonsoft.cs
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.Newtonsoft.cs
@@ -1,0 +1,35 @@
+﻿
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.Fdc3.NewtonsoftJson.Serialization;
+using Newtonsoft.Json;
+
+namespace MorganStanley.Fdc3.AppDirectory.Tests
+{
+    public partial class DeserializationTest
+    {
+        [Fact]
+        public void AppDAppDeserializationTest_Newtonsoft()
+        {
+            string jsonString = File.ReadAllText("TestJsons\\SampleAppForInterop.json");
+
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+            Fdc3App app = JsonConvert.DeserializeObject<Fdc3App>(jsonString, new Fdc3JsonSerializerSettings());
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+
+            ValidateApp(app!);
+        }
+    }
+}

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.SystemTextJson.cs
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.SystemTextJson.cs
@@ -1,0 +1,35 @@
+﻿
+/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.Fdc3.Json.Serialization;
+using System.Text.Json;
+
+namespace MorganStanley.Fdc3.AppDirectory.Tests
+{
+    public partial class DeserializationTest
+    {
+        [Fact]
+        public void AppDAppDeserializationTest_SystemTextJson()
+        {
+            string jsonString = File.ReadAllText("TestJsons\\SampleAppForInterop.json");
+
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+            Fdc3App app = JsonSerializer.Deserialize<Fdc3App>(jsonString, Fdc3JsonSerializerOptions.Create());
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+
+            ValidateApp(app!);
+        }
+    }
+}

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.cs
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/DeserializationTest.cs
@@ -13,22 +13,12 @@
  * and limitations under the License.
  */
 
-using MorganStanley.Fdc3.NewtonsoftJson.Serialization;
-using Newtonsoft.Json;
-
 namespace MorganStanley.Fdc3.AppDirectory.Tests
 {
-    public class DeserializationTest
+    public partial class DeserializationTest
     {
-        [Fact]
-        public void AppDAppDeserializationTest()
+        protected void ValidateApp(Fdc3App app)
         {
-            string jsonString = File.ReadAllText("TestJsons\\SampleAppForInterop.json");
-
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-            Fdc3App app = JsonConvert.DeserializeObject<Fdc3App>(jsonString, new Fdc3JsonSerializerSettings());
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-
             Assert.Equal("my-application", app!.AppId);
             Assert.Equal("my-application", app.Name);
             Assert.Equal("My Application", app.Title);
@@ -76,7 +66,6 @@ namespace MorganStanley.Fdc3.AppDirectory.Tests
             Assert.Contains("myApp.quote", app.Interop.AppChannels!.First().Broadcasts!);
             Assert.Contains("fdc3.instrument", app.Interop.AppChannels!.First().ListensFor!);
             Assert.Contains("fr-FR", app.LocalizedVersions!.Keys);
-
         }
     }
 }

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/MorganStanley.Fdc3.AppDirectory.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/MorganStanley.Fdc3.AppDirectory.Tests.csproj
@@ -35,6 +35,7 @@
     <ProjectReference Include="..\..\Fdc3.NewtonsoftJson\MorganStanley.Fdc3.NewtonsoftJson.csproj" />
     <ProjectReference Include="..\..\Fdc3.AppDirectory\MorganStanley.Fdc3.AppDirectory.csproj" />
     <ProjectReference Include="..\..\Fdc3.NewtonsoftJson\MorganStanley.Fdc3.NewtonsoftJson.csproj" />
+    <ProjectReference Include="..\..\MorganStanley.Fdc3.Json\MorganStanley.Fdc3.Json.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/TestJsons/SampleAppForInterop.json
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/TestJsons/SampleAppForInterop.json
@@ -5,7 +5,7 @@
     "description": "An example application that uses FDC3 and fully describes itself in an AppD record.",
     "categories": [ "market data", "research", "news" ],
     "version": "1.0.0",
-    "tooltip": "My example application definition",
+    "toolTip": "My example application definition",
     "lang": "en-US",
     "icons": [
         {
@@ -32,7 +32,7 @@
     "supportEmail": "fdc3-maintainers@finos.org",
     "moreInfo": "http://example.domain.com/",
     "publisher": "Example App, Inc.",
-    "type": "web",
+    "type": "Web",
     "details": { "url": "http://example.domain.com/app.html" },
     "hostManifests": {
         "Finsemble": {

--- a/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/TestJsons/SampleAppForInterop.json
+++ b/src/Tests/MorganStanley.Fdc3.AppDirectory.Tests/TestJsons/SampleAppForInterop.json
@@ -32,7 +32,7 @@
     "supportEmail": "fdc3-maintainers@finos.org",
     "moreInfo": "http://example.domain.com/",
     "publisher": "Example App, Inc.",
-    "type": "Web",
+    "type": "web",
     "details": { "url": "http://example.domain.com/app.html" },
     "hostManifests": {
         "Finsemble": {

--- a/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/Context/ContextSchemaTest.cs
+++ b/src/Tests/MorganStanley.Fdc3.NewtonsoftJson.Tests/Context/ContextSchemaTest.cs
@@ -21,7 +21,7 @@ using System.Reflection;
 
 namespace MorganStanley.Fdc3.NewtonsoftJson.Tests.Context;
 
-public abstract partial class ContextSchemaTest
+public abstract class ContextSchemaTest
 {
     protected JSchema? Schema { get; private set; }
     protected string SchemaUrl { get; private set; }

--- a/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/EmailTests.cs
+++ b/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/EmailTests.cs
@@ -1,0 +1,68 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using MorganStanley.Fdc3.Context;
+using MorganStanley.Fdc3.Json.Serialization;
+using System.Reflection;
+using System.Text.Json;
+
+namespace MorganStanley.Fdc3.SystemTextJson.Tests
+{
+    public class EmailTests
+    {
+        [Fact]
+        public void Email_Contact_DeserializedJsonMatchesProperties()
+        {
+            Email? email = Deserialize<Email>("MorganStanley.Fdc3.SystemTextJson.Tests.Examples.email-contact.json");
+            Assert.NotNull(email);
+            Contact? contact = email?.Recipients as Contact;
+            Assert.Equal("email", contact?.ID?.Email);
+            Assert.Equal("fdsid", contact?.ID?.FdsId);
+            Assert.Equal("subject", email?.Subject);
+            Assert.Equal("body", email?.TextBody);
+            Assert.Equal("email", email?.Name);
+        }
+
+        [Fact]
+        public void Email_ContactList_DeserializedJsonMatchesProperties()
+        {
+            Email? email = Deserialize<Email>("MorganStanley.Fdc3.SystemTextJson.Tests.Examples.email-contactList.json");
+            Assert.NotNull(email);
+            ContactList? contactList = email?.Recipients as ContactList;
+            Contact? contact = contactList?.Contacts?.First<Contact>();
+            Assert.Equal("email", contact?.ID?.Email);
+            Assert.Equal("fdsid", contact?.ID?.FdsId);
+            Assert.Equal("subject", email?.Subject);
+            Assert.Equal("body", email?.TextBody);
+            Assert.Equal("email", email?.Name);
+        }
+
+        protected T? Deserialize<T>(string resourcePath) where T : class, IContext
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            using (Stream? stream = assembly.GetManifestResourceStream(resourcePath))
+            {
+                if (stream != null)
+                {
+                    using (StreamReader reader = new StreamReader(stream))
+                    {
+                        return JsonSerializer.Deserialize<T>(reader.ReadToEnd(), Fdc3JsonSerializerOptions.Create());
+                    }
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/MorganStanley.Fdc3.SystemTextJson.Tests.csproj
+++ b/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/MorganStanley.Fdc3.SystemTextJson.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="..\MorganStanley.Fdc3.NewtonsoftJson.Tests\Context\Examples\email-contact.json" Link="Examples\email-contact.json" />
+    <EmbeddedResource Include="..\MorganStanley.Fdc3.NewtonsoftJson.Tests\Context\Examples\email-contactList.json" Link="Examples\email-contactList.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Examples\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Fdc3\MorganStanley.Fdc3.csproj" />
+    <ProjectReference Include="..\..\MorganStanley.Fdc3.Json\MorganStanley.Fdc3.Json.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/Usings.cs
+++ b/src/Tests/MorganStanley.Fdc3.SystemTextJson.Tests/Usings.cs
@@ -12,22 +12,4 @@
  * and limitations under the License.
  */
 
-namespace MorganStanley.Fdc3.Context
-{
-    public class Email : Context, IContext
-    {
-        public Email(IRecipient recipients, string? subject = null, string? textBody = null, object? id = null, string? name = null)
-            : base(ContextTypes.Email, id, name)
-        {
-            this.Recipients = recipients;
-            this.Subject = subject;
-            this.TextBody = textBody;
-        }
-
-        public IRecipient Recipients { get; set; }
-        public string? Subject { get; set; }
-        public string? TextBody { get; set; }
-
-        object? IContext<object>.ID => base.ID;
-    }
-}
+global using Xunit;

--- a/src/fdc3-dotnet.sln
+++ b/src/fdc3-dotnet.sln
@@ -46,6 +46,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MorganStanley.Fdc3.AppDirec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MorganStanley.Fdc3.AppDirectory.Tests", "Tests\MorganStanley.Fdc3.AppDirectory.Tests\MorganStanley.Fdc3.AppDirectory.Tests.csproj", "{88BF9BA6-2934-4904-8952-DB733E4CBD48}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MorganStanley.Fdc3.Json", "MorganStanley.Fdc3.Json\MorganStanley.Fdc3.Json.csproj", "{9B855057-CCD6-4A5D-BF47-0D843F5D18E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MorganStanley.Fdc3.SystemTextJson.Tests", "Tests\MorganStanley.Fdc3.SystemTextJson.Tests\MorganStanley.Fdc3.SystemTextJson.Tests.csproj", "{54E6B0C9-176A-43CC-9D1E-D37C22349F0E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +84,14 @@ Global
 		{88BF9BA6-2934-4904-8952-DB733E4CBD48}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{88BF9BA6-2934-4904-8952-DB733E4CBD48}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88BF9BA6-2934-4904-8952-DB733E4CBD48}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B855057-CCD6-4A5D-BF47-0D843F5D18E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B855057-CCD6-4A5D-BF47-0D843F5D18E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B855057-CCD6-4A5D-BF47-0D843F5D18E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B855057-CCD6-4A5D-BF47-0D843F5D18E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54E6B0C9-176A-43CC-9D1E-D37C22349F0E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54E6B0C9-176A-43CC-9D1E-D37C22349F0E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54E6B0C9-176A-43CC-9D1E-D37C22349F0E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54E6B0C9-176A-43CC-9D1E-D37C22349F0E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -90,6 +102,7 @@ Global
 		{A4FC0A7A-AD7D-4FDD-8143-46A63A65C96E} = {97CAC97B-DB3A-4A45-9209-3BAD231B4837}
 		{06AD2640-C708-4C01-BF02-82D824CB09C1} = {6C9A6509-FC32-4870-8AD3-9D0AE546A3D9}
 		{88BF9BA6-2934-4904-8952-DB733E4CBD48} = {97CAC97B-DB3A-4A45-9209-3BAD231B4837}
+		{54E6B0C9-176A-43CC-9D1E-D37C22349F0E} = {97CAC97B-DB3A-4A45-9209-3BAD231B4837}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {356A9BB9-BD56-40C0-B1ED-06F7AF0C4BCA}


### PR DESCRIPTION
Created a new project called MorganStanley.Fdc3.Json which provides NET Standard 2.0 helpers based on System.Text.Json.
Also changed the constructor argument name of the Email class from `recipient` to `recipients` to match the property name. 
Fixed the casing of `toolTip` in the test data for AppDirectory tests.

--
THIS MATERIAL IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS MATERIAL IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS MATERIAL, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS MATERIAL MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.