### PR TITLE
Remove sha1 matching for false positives

### DIFF
--- a/.cve/allow-list.xml
+++ b/.cve/allow-list.xml
@@ -4,35 +4,30 @@
    <notes><![CDATA[
    file name: MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
    ]]></notes>
-   <sha1>d2ff25b0a18b7fb7c16afba4dd9daad5462b0c80</sha1>
    <cve>CVE-2022-25921</cve>
 </suppress>
 <suppress>
    <notes><![CDATA[
    file name: MorganStanley.Fdc3.NewtonsoftJson.csproj
    ]]></notes>
-   <sha1>ec9ad28356158b425a7f32919bb5bad854ec0497</sha1>
    <cve>CVE-2022-25921</cve>
 </suppress>
 <suppress>
    <notes><![CDATA[
    file name: MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
    ]]></notes>
-   <sha1>ab20542dabf29dcb95f00a3e121a0ba6520fa587</sha1>
    <cpe>cpe:/a:json_project:json</cpe>
 </suppress>
 <suppress>
    <notes><![CDATA[
    file name: MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
    ]]></notes>
-   <sha1>ab20542dabf29dcb95f00a3e121a0ba6520fa587</sha1>
    <cpe>cpe:/a:morgan-json_project:morgan-json</cpe>
 </suppress>
 <suppress>
    <notes><![CDATA[
    file name: MorganStanley.Fdc3.NewtonsoftJson.Tests.csproj
    ]]></notes>
-   <sha1>ab20542dabf29dcb95f00a3e121a0ba6520fa587</sha1>
    <cpe>cpe:/a:morgan_project:morgan</cpe>
 </suppress>
 </suppressions>


### PR DESCRIPTION
Having the sha1 match was causing false positives to reoccur on every edit of project files.

---
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.
 
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS. 