### PR TITLE
Correct API declaration of GetResult to be nullable

### DIFF
--- a/src/Fdc3/IIntentResolution.cs
+++ b/src/Fdc3/IIntentResolution.cs
@@ -36,6 +36,6 @@ namespace Finos.Fdc3
         /// </summary>
         string? Version { get; }
 
-        Task<IIntentResult> GetResult();
+        Task<IIntentResult?> GetResult();
     }
 }

--- a/src/Fdc3/IntentResolution.cs
+++ b/src/Fdc3/IntentResolution.cs
@@ -44,6 +44,6 @@ namespace Finos.Fdc3
         /// </summary>
         public string? Version { get; }
 
-        public abstract Task<IIntentResult> GetResult();
+        public abstract Task<IIntentResult?> GetResult();
     }
 }

--- a/src/Tests/Finos.Fdc3.Tests/IntentResolutionTests.cs
+++ b/src/Tests/Finos.Fdc3.Tests/IntentResolutionTests.cs
@@ -55,7 +55,7 @@ public class IntentResolutionTests
         {
         }
 
-        public override Task<IIntentResult> GetResult()
+        public override Task<IIntentResult?> GetResult()
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
As per https://github.com/finos/FDC3/issues/1107, backport fix of IntentResult to allow null.  While this is a breaking interface change to API implementors it will be released under the new Finos.Fdc3 beta nuget moving forward.

---
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.
 
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.