### PR TITLE
Suppress false positive for CVE-2024-21907

### DIFF
--- a/.cve/allow-list.xml
+++ b/.cve/allow-list.xml
@@ -30,4 +30,11 @@
    ]]></notes>
    <cpe>cpe:/a:morgan_project:morgan</cpe>
 </suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: Newtonsoft.Json.Schema.dll
+   ]]></notes>
+   <packageUrl regex="true">^pkg:generic/Newtonsoft\.Json\.Schema@.*$</packageUrl>
+   <cve>CVE-2024-21907</cve>
+</suppress>
 </suppressions>


### PR DESCRIPTION
Suppress low confidence erroneous match of Newtonsoft.Json.Schema.dll to CVE for Newtonsoft.Json.  The Newtonsoft.Json upgrade was done in #103

---
THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS CORPORATE CONTRIBUTOR LICENSE AGREEMENT.
 
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.