### PR TITLE
Add custom JsonConverters for Intents 

### DIFF
--- a/src/Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
+++ b/src/Fdc3.Json/Serialization/Fdc3JsonSerializerOptions.cs
@@ -21,16 +21,20 @@ namespace Finos.Fdc3.Json.Serialization
     {
         public static JsonSerializerOptions Create()
         {
+            var options = CreateWithoutConverters();
+            options.Converters.Add(new JsonStringEnumConverter(new Fdc3CamelCaseNamingPolicy()));
+            options.Converters.Add(new Fdc3AppConverter());
+            options.Converters.Add(new RecipientJsonConverter());
+            options.Converters.Add(new IntentsConverter());
+            return options;
+        }
+
+        internal static JsonSerializerOptions CreateWithoutConverters()
+        {
             return new JsonSerializerOptions
             {
                 ReferenceHandler = ReferenceHandler.IgnoreCycles,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                Converters =
-                {
-                   new JsonStringEnumConverter(new Fdc3CamelCaseNamingPolicy()),
-                   new Fdc3AppConverter(),
-                   new RecipientJsonConverter()
-                },
                 PropertyNamingPolicy = new Fdc3CamelCaseNamingPolicy()
             };
         }

--- a/src/Fdc3.Json/Serialization/IntentsConverter.cs
+++ b/src/Fdc3.Json/Serialization/IntentsConverter.cs
@@ -1,0 +1,43 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using Finos.Fdc3.AppDirectory;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Finos.Fdc3.Json.Serialization
+{
+    public class IntentsConverter : JsonConverter<Intents>
+    {
+        public override Intents? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var result = JsonSerializer.Deserialize<Intents>(ref reader, Fdc3JsonSerializerOptions.CreateWithoutConverters());
+            if (result?.ListensFor != null)
+            {
+                foreach (var intentName in result.ListensFor.Keys)
+                {
+                    result.ListensFor[intentName].Name = intentName;
+                }
+            }
+
+            return result;
+        }
+
+        public override void Write(Utf8JsonWriter writer, Intents value, JsonSerializerOptions options)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Fdc3.NewtonsoftJson/Serialization/Fdc3JsonSerializerSettings.cs
+++ b/src/Fdc3.NewtonsoftJson/Serialization/Fdc3JsonSerializerSettings.cs
@@ -30,7 +30,13 @@ namespace Finos.Fdc3.NewtonsoftJson.Serialization
             {
                 NamingStrategy = new Fdc3CamelCaseNamingStrategy()
             };
-            this.Converters = new JsonConverter[] { new StringEnumConverter(new CamelCaseNamingStrategy()), new RecipientJsonConverter(), new Fdc3AppConverter() };
+            this.Converters = new JsonConverter[]
+            {
+                new StringEnumConverter(new CamelCaseNamingStrategy()), 
+                new RecipientJsonConverter(), 
+                new Fdc3AppConverter(), 
+                new IntentsConverter()
+            };
         }
     }
 }

--- a/src/Fdc3.NewtonsoftJson/Serialization/IntentsConverter.cs
+++ b/src/Fdc3.NewtonsoftJson/Serialization/IntentsConverter.cs
@@ -1,0 +1,52 @@
+﻿/*
+ * Morgan Stanley makes this available to you under the Apache License,
+ * Version 2.0 (the "License"). You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership. Unless required by applicable law or agreed
+ * to in writing, software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+using Finos.Fdc3.AppDirectory;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace Finos.Fdc3.NewtonsoftJson.Serialization
+{
+    public class IntentsConverter : JsonConverter<Intents>
+    {
+        public override bool CanWrite => false;
+
+        public override Intents? ReadJson(JsonReader reader, Type objectType, Intents? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            var obj = JObject.Load(reader);
+            var result = obj.ToObject(typeof(Intents)) as Intents;
+
+            if (result?.ListensFor != null)
+            {
+                foreach (var intentName in result.ListensFor.Keys)
+                {
+                    result.ListensFor[intentName].Name = intentName;
+                }
+            }
+
+            return result;
+        }
+
+        public override void WriteJson(JsonWriter writer, Intents? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Tests/Finos.Fdc3.AppDirectory.Tests/DeserializationTest.cs
+++ b/src/Tests/Finos.Fdc3.AppDirectory.Tests/DeserializationTest.cs
@@ -54,6 +54,8 @@ namespace Finos.Fdc3.AppDirectory.Tests
             Assert.Contains("fdc3.instrument", app.Interop!.Intents!.ListensFor!["myApp.GetPrice"].Contexts!);
             Assert.Equal("Get Price", app.Interop!.Intents!.ListensFor!["myApp.GetPrice"].DisplayName);
             Assert.Equal("myApp.quote", app.Interop!.Intents!.ListensFor!["myApp.GetPrice"].ResultType);
+            Assert.Equal("ViewChart", app.Interop!.Intents!.ListensFor!["ViewChart"].Name);
+            Assert.Equal("myApp.GetPrice", app.Interop!.Intents!.ListensFor!["myApp.GetPrice"].Name);
             Assert.Contains("ViewOrders", app.Interop.Intents.Raises!.Keys);
             Assert.Contains("fdc3.instrument", app.Interop.Intents.Raises!["ViewOrders"]);
             Assert.Contains("StartEmail", app.Interop.Intents.Raises.Keys);


### PR DESCRIPTION
Add custom JsonConverters for Intents to set the Name property with the key of the dictionary) during deserialization. 
Fixes #115

THIS MATERIAL IS CONTRIBUTED SUBJECT TO THE TERMS OF THE FINOS Corporate Contributor License Agreement.

THIS MATERIAL IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS MATERIAL, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS MATERIAL MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
